### PR TITLE
Enabled multiple correct puzzle submissions for users with draft access

### DIFF
--- a/app/helpers/puzzles_helper.rb
+++ b/app/helpers/puzzles_helper.rb
@@ -1,2 +1,7 @@
 module PuzzlesHelper
+
+  def show_solution_button?(user, puzzle)
+    (user && user.draft_access?) || !puzzle.answered_correctly?(user)
+  end
+
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -19,7 +19,7 @@ class Submission < ActiveRecord::Base
   end
 
   def only_one_correct_submission_per_puzzle_per_user
-    if user.try(:solution_for, puzzle)
+    if user && !user.draft_access && user.solution_for(puzzle)
       errors[:base] << "You've already solved this puzzle!"
       return false
     end

--- a/app/views/puzzles/_action_button.html.haml
+++ b/app/views/puzzles/_action_button.html.haml
@@ -3,6 +3,6 @@
 - if puzzle.answered_correctly? current_user
   %button.clean-gray{:'data-url' => puzzle_comments_path(puzzle), :class => size}
     View Discussion
-- else
+- if show_solution_button?(current_user, puzzle)
   %button.clean-gray{:'data-url' => new_puzzle_submission_path(puzzle), :class => size}
     Submit your solution

--- a/test/unit/submission_test.rb
+++ b/test/unit/submission_test.rb
@@ -28,4 +28,11 @@ class SubmissionTest < ActiveSupport::TestCase
 
     assert second_submission.new_record?, "Record saved when it shouldn't"
   end
+
+  test "for users with draft access multiple correct submissions are possible" do
+    @user.update_attribute(:draft_access, true)
+    second_submission = @user.submissions.create(:puzzle => @puzzle, :file => @file)
+
+    assert !second_submission.new_record?, "Record not saved when it should have been"
+  end
 end


### PR DESCRIPTION
Multiple correct submissions now possible for users with draft access. Also, "Submit your solution" button is visible to users with draft access at all times.
