### PR TITLE
Issue 44 - adding rake setup task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'jquery-rails'
 
 gem 'capistrano'
 gem 'exception_notification'
+gem 'highline', '~> 1.6.9'
 
 group :assets do
   gem 'sass-rails',   '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     ffi (1.0.9)
     fssm (0.2.7)
     haml (3.1.3)
-    highline (1.6.2)
+    highline (1.6.9)
     hike (1.2.1)
     i18n (0.6.0)
     jquery-rails (1.0.14)
@@ -235,6 +235,7 @@ DEPENDENCIES
   exception_notification
   factory_girl_rails
   haml
+  highline (~> 1.6.9)
   jquery-rails
   omniauth (~> 0.2.5)
   pg

--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,14 @@ $ rake db:create
 $ rake db:schema:load
 ```
 
+To make things even easier, you can copy and paste this into your terminal once you've got the project cloned to your computer
+
+```bash
+gem install bundler
+bundle install
+bundle exec rake setup
+```
+
 Finally, run the test suite to make sure everything is working correctly:
 
 ```bash

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,0 +1,98 @@
+require 'fileutils'
+require 'highline'
+
+HighLine.colorize_strings
+
+desc 'runs the tasks necessary to setup PuzzleNode'
+task :setup do
+
+  section "Configuration Files" do
+
+    database_file     = File.join(Rails.root, 'config', 'database.yml')
+    omniauth_file     = File.join(Rails.root, 'config', 'omniauth.yml')
+    secret_token_file = File.join(Rails.root, 'config', 'initializers', 'secret_token.rb')
+
+    unless File.exists?(database_file)
+      FileUtils.cp(database_file + '.example', database_file)
+      puts "Database config file created".color(:green)
+      puts "Update #{database_file} and run `bundle exec rake setup` to continue".color(:red)
+      `$EDITOR #{database_file}`
+      exit
+    else
+      puts "Database config file already exists"
+    end
+
+    unless File.exists?(omniauth_file)
+      FileUtils.cp(omniauth_file + '.example', omniauth_file)
+      puts "OmniAuth config file created".color(:green)
+      puts "Update #{omniauth_file} and run `bundle exec rake setup` to continue".color(:red)
+      `$EDITOR #{omniauth_file}`
+      exit
+    else
+      puts "OmniAuth config file already exists"
+    end
+
+    unless File.exists?(secret_token_file)
+      FileUtils.cp(secret_token_file + '.example', secret_token_file)
+      token = `rake secret`
+
+      text = File.read(secret_token_file)
+      replace = text.gsub(/<RUN `rake secret` TO GENERATE A TOKEN>/, token.chomp)
+      File.open(secret_token_file, "w") {|file| file.puts replace}
+
+      puts "Secret Token file created".color(:green)
+    else
+      puts "Secret Token file already exists"
+    end
+
+  end
+
+  section "Database" do
+    begin
+      # Check if there are pending migrations
+      silence { Rake::Task["db:abort_if_pending_migrations"].invoke }
+      puts "Skip: Database already setup"
+    rescue Exception
+      silence do
+        Rake::Task["db:create"].invoke
+        Rake::Task["db:schema:load"].invoke
+      end
+      puts "Database setup"
+    end
+  end
+
+  puts # Empty Line
+  puts "==== Setup Complete ====".color(:green)
+  puts # Empty Line
+
+end
+
+private
+
+def section(description)
+  puts # Empty Line
+  puts description.underline
+  puts # Empty Line
+  yield
+end
+
+def silence
+  begin
+    orig_stderr = $stderr.clone
+    orig_stdout = $stdout.clone
+
+    $stderr.reopen File.new('/dev/null', 'w')
+    $stdout.reopen File.new('/dev/null', 'w')
+
+    return_value = yield
+  rescue Exception => e
+    $stdout.reopen orig_stdout
+    $stderr.reopen orig_stderr
+    raise e
+  ensure
+    $stdout.reopen orig_stdout
+    $stderr.reopen orig_stderr
+  end
+
+  return_value
+end


### PR DESCRIPTION
Pulled in the setup task from MoM and changed to work with puzzlenode. It creates database.yml, omniauth.yml and secret_token.rb and then runs the database rake tasks. Also updated the README.

Note: I had to update the 'highline' gem to get the colorize strings methods used in the rake task.
